### PR TITLE
Fix tests under Qt 5.14

### DIFF
--- a/tests/tst_GSettings.qml
+++ b/tests/tst_GSettings.qml
@@ -12,7 +12,7 @@ TestCase {
     id: settings
     schema.id: "com.canonical.gsettings.Test"
     // has to be "valueChanged" signal, not "changed"; the latter doesn't work reliably with the in-memory gsettings backend
-    onValueChanged: changes.push([key, value]);
+    onValueChanged: testCase.changes.push([key, value]);
   }
 
   SignalSpy {


### PR DESCRIPTION
Otherwise the following error happens:
```
QWARN  : GSettings::test_changed() file:///[...]/gsettings-qt/tests/tst_GSettings.qml:15: TypeError: Cannot call method 'push' of undefined
```