### PR TITLE
Declare libgsettings-qt dependency for cpptest

### DIFF
--- a/gsettings-qt.pro
+++ b/gsettings-qt.pro
@@ -1,2 +1,14 @@
 TEMPLATE = subdirs
-SUBDIRS += src/gsettings-qt.pro GSettings/gsettings-qt.pro tests/tests.pro tests/cpptest.pro
+SUBDIRS += \
+    libgsettings-qt \
+    gsettings-qt \
+    tests \
+    cpptest
+
+libgsettings-qt.file = src/gsettings-qt.pro
+gsettings-qt.file = GSettings/gsettings-qt.pro
+gsettings-qt.depends = libgsettings-qt
+
+tests.file = tests/tests.pro
+cpptest.file = tests/cpptest.pro
+cpptest.depends = libgsettings-qt


### PR DESCRIPTION
Resolves cpptest sometimes being linked before libgsettings-qt was
built which resulted in an error.

Fixes #2