### PR TITLE
Fix 'make install' on Alpine Linux

### DIFF
--- a/GSettings/gsettings-qt.pro
+++ b/GSettings/gsettings-qt.pro
@@ -25,6 +25,6 @@ INSTALLS += extra
 
 qmltypes.path = $$installPath
 qmltypes.files = plugins.qmltypes
-qmltypes.extra = export LD_PRELOAD=../src/libgsettings-qt.so.1; $$[QT_INSTALL_BINS]/qmlplugindump -notrelocatable GSettings 1.0 .. > $(INSTALL_ROOT)/$$installPath/plugins.qmltypes
+qmltypes.extra = export LD_LIBRARY_PATH=$$PWD/../src; $$[QT_INSTALL_BINS]/qmlplugindump -notrelocatable GSettings 1.0 .. > $(INSTALL_ROOT)/$$installPath/plugins.qmltypes
 INSTALLS += qmltypes
 


### PR DESCRIPTION
I'm not quite sure what the actual problem and why it doesn't work (musl
problem?, toolchain problem?) but here are the results from my
investigation:

* Relative and absolute LD_PRELOAD doesn't work
* Relative LD_LIBRARY_PATH doesn't work
* Absolute LD_LIBRARY_PATH *does* work

So let's use the absolute LD_LIBRARY_PATH.